### PR TITLE
Individuelle Sprachauswahl

### DIFF
--- a/Migrations/20230210094911_AddUserLocale.Designer.cs
+++ b/Migrations/20230210094911_AddUserLocale.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -9,9 +10,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ZebrafischBot.Migrations
 {
     [DbContext(typeof(StorageContext))]
-    partial class StorageContextModelSnapshot : ModelSnapshot
+    [Migration("20230210094911_AddUserLocale")]
+    partial class AddUserLocale
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.0");

--- a/Migrations/20230210094911_AddUserLocale.cs
+++ b/Migrations/20230210094911_AddUserLocale.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ZebrafischBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserLocale : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Locale",
+                table: "Users",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Locale",
+                table: "Users");
+        }
+    }
+}

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -103,6 +103,8 @@ public class DBGuild
 public class DBUser
 {
     public ulong Id { get; set; }
+
+    public string? Locale { get; set; }
 }
 
 public class DBMessage

--- a/modules/CommandCog.cs
+++ b/modules/CommandCog.cs
@@ -5,6 +5,9 @@ using DSharpPlus.CommandsNext.Attributes;
 public abstract class CommandCog : BaseCommandModule 
 {
 
+    public StorageContext DB { get; set; }
+    public Localiser Loc { get; set;}
+
     public virtual string CogName
     {
         get {
@@ -19,5 +22,18 @@ public abstract class CommandCog : BaseCommandModule
         var guildinfo = await storage.GetGuildInfo(ctx.Guild.Id);
         if (!guildinfo.ActivatedCogs.Contains(CogName)) throw new ChecksFailedException(ctx.Command, ctx, new CheckBaseAttribute[] {});
         await base.BeforeExecutionAsync(ctx);
+    }
+
+    public async Task<string> TranslateString(string token, CommandContext ctx) 
+    {
+        var userLocale = (await DB.GetUserInfo(ctx.User.Id)).Locale;
+        if (userLocale == null || userLocale.Equals("")) userLocale = (await DB.GetGuildInfo(ctx.Guild.Id)).Locale;
+        return Loc.GetString(userLocale, token);
+    }
+
+    public async Task<string> FormatString(string token, CommandContext ctx, params string[] inserts)
+    {
+        var str = await TranslateString(token, ctx);
+        return String.Format(str, inserts);
     }
 }

--- a/modules/RuleApprobation.cs
+++ b/modules/RuleApprobation.cs
@@ -7,9 +7,6 @@ public class RuleApprobation : CommandCog
 {
     public override string CogName => "rouxls";
 
-    public StorageContext DB { private get; set; }
-    public Localiser Loc {private get; set;}
-
     [Command("setrole")]
     [RequirePermissions(DSharpPlus.Permissions.ManageRoles)]
     public async Task SetRoleCommand(CommandContext ctx, DiscordRole role) 
@@ -18,7 +15,7 @@ public class RuleApprobation : CommandCog
         channel.RouxlsRole = role.Id;
         DB.Entry(channel).State = Microsoft.EntityFrameworkCore.EntityState.Modified;
         await DB.SaveChangesAsync();
-        await ctx.RespondAsync(Loc.FormatString((await DB.GetGuildInfo(ctx.Guild.Id)).Locale, "rouxls.setRoleResp", ctx.Guild.GetRole(channel.RouxlsRole).Name));
+        await ctx.RespondAsync(await FormatString("rouxls.setRoleResp", ctx, ctx.Guild.GetRole(channel.RouxlsRole).Name));
     }
 
     [Command("accept")]


### PR DESCRIPTION
Nutzerspezifische Sprachauswahl wird durch eine _Locale_-Spalte für _User_ und die zugehörigen Commands möglich. Zudem wurde die Sprachermittlung für Bot-Module ausgelagert.